### PR TITLE
ci: add cargo check and cargo clippy pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
This PR adds a GitHub Actions CI workflow that runs on every push and pull request to `main`.

## Jobs
- `cargo check --all-targets` on ubuntu-latest with stable Rust
- `cargo clippy --all-targets -- -D warnings` on ubuntu-latest with stable Rust

Both jobs use `Swatinem/rust-cache@v2` to keep CI times reasonable.