### PR TITLE
Fix macos base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.direnv
+.envrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,16 +3667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,7 +4649,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "tokio",
- "users",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ nix = { version = "0.30.1", features = ["user"] }
 rand = "0.8.5"
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["net"] }
-users = "0.11.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     };
     if let Err(e) = res {
         println!("Error, terminated due to:");
-        println!("{e}");
+        println!("{e:#}");
         exit(1);
     }
 }

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -13,7 +13,6 @@ use tokio::{
     net::{UnixListener, UnixStream},
     spawn,
 };
-use users::get_current_uid;
 
 use crate::protocol::{EasyCodeRead, EasyCodeWrite};
 
@@ -137,7 +136,7 @@ pub async fn join(c: Connection) -> Result<()> {
     println!("Remote Session is {name}. You too are expected to use version {version}.");
 
     let remote_session_name = format!("{name}-remote");
-    let dir = format!("/run/user/{}/zellij/{}", get_current_uid(), version);
+    let dir = get_base_path()?.join(version).display().to_string();
     create_dir_all(&dir)
         .await
         .context("Failed to create zellij directory")?;


### PR DESCRIPTION
As the commit messages say, this change prints the whole error chain when terminating due to an error, and uses `get_base_path()` instead of the hardcoded linux runtime dir when joining a remote session so that joining works on MacOS. It also adds to `.gitignore` a couple files related to [direnv](https://direnv.net/) which I use for clean environment config management, and I will happily remove these if you prefer.

I tested hosting and joining manually from NixOS and MacOS Tahoe.

During this testing I also noticed there's no exit cleanup/signal handling and socket files get leftover, and I may follow up with something for this.