### PR TITLE
Implement guard on socket file for cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2765,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3213,19 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -4192,7 +4224,9 @@ dependencies = [
  "nix",
  "rand 0.8.6",
  "serde",
+ "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,8 @@ iroh = "1.0.0"
 nix = { version = "0.30.1", features = ["user"] }
 rand = "0.8.5"
 serde = { version = "1.0.217", features = ["derive"] }
-tokio = { version = "1.43.0", features = ["net"] }
+tokio = { version = "1.43.0", features = ["net", "signal"] }
+tokio-util = { version = "0.7.18" }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/src/guarded_socket.rs
+++ b/src/guarded_socket.rs
@@ -18,7 +18,7 @@ impl GuardedSocket {
 
         let listener = UnixListener::bind(&path).context(format!(
             "Failed to create socket file at {}.",
-            &path.display()
+            path.display()
         ))?;
 
         Ok(GuardedSocket {
@@ -32,7 +32,7 @@ impl GuardedSocket {
         let err = match UnixStream::connect(&path).await {
             Ok(_) => {
                 // success means the socket is live, so something else is using it
-                bail!("Another process is using the live socket at {} -- is another zeco client already running and connected to the same session?", &path.display())
+                bail!("Another process is using the live socket at {} -- is another zeco client already running and connected to the same session?", path.display())
             }
             Err(e) => e,
         };
@@ -74,5 +74,48 @@ impl Drop for GuardedSocket {
                 err
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::exists;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_handles_stale_socket_files() -> Result<()> {
+        let dir = tempdir()?;
+        let stale_socket_path = dir.path().join("zeco-test-socket");
+        let stale_socket = UnixListener::bind(&stale_socket_path)
+            .context("Couldn't bind to the test socket path to create a stale socket.")?;
+        drop(stale_socket); // closes file descriptor, but file remains
+        GuardedSocket::bind(stale_socket_path)
+            .await
+            .context("Couldn't bind to stale socket at test_socket_path.")?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn bind_doesnt_remove_live_sockets() -> Result<()> {
+        let dir = tempdir()?;
+        let live_socket_path = dir.path().join("zeco-test-socket");
+        let _live_socket = UnixListener::bind(&live_socket_path)
+            .context("Couldn't bind to the test socket path to create a live socket.")?;
+        assert!(GuardedSocket::bind(live_socket_path.clone()).await.is_err());
+        assert!(exists(live_socket_path).is_ok_and(|file_exists| file_exists));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn guarded_socket_gets_cleaned_up() -> Result<()> {
+        let dir = tempdir()?;
+        let guarded_socket_path = dir.path().join("zeco-test-socket");
+        let guarded_socket = GuardedSocket::bind(guarded_socket_path.clone()).await?;
+        assert!(exists(&guarded_socket_path).is_ok_and(|file_exists| file_exists));
+        drop(guarded_socket);
+        assert!(exists(guarded_socket_path).is_ok_and(|file_exists| !file_exists));
+        Ok(())
     }
 }

--- a/src/guarded_socket.rs
+++ b/src/guarded_socket.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tokio::net::{unix::SocketAddr, UnixListener, UnixStream};
+
+pub struct GuardedSocket {
+    listener: Option<UnixListener>,
+    path: PathBuf,
+}
+
+impl GuardedSocket {
+    pub async fn accept(&self) -> Result<(UnixStream, SocketAddr)> {
+        Ok(self.listener.as_ref().unwrap().accept().await?)
+    }
+
+    pub fn bind(path: PathBuf) -> Result<GuardedSocket> {
+        let listener = UnixListener::bind(&path).context(format!(
+            "Failed to create socket file at {}.",
+            &path.display()
+        ))?;
+        Ok(GuardedSocket {
+            listener: Some(listener),
+            path,
+        })
+    }
+}
+
+impl Drop for GuardedSocket {
+    fn drop(&mut self) {
+        // Ensure we close file descriptor by dropping listener before unlinking
+        drop(self.listener.take());
+        let result = std::fs::remove_file(&self.path);
+        if let Err(err) = result {
+            println!(
+                "Warning: Failed to remove socket file during cleanup: {}",
+                err
+            )
+        }
+    }
+}

--- a/src/guarded_socket.rs
+++ b/src/guarded_socket.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use tokio::net::{unix::SocketAddr, UnixListener, UnixStream};
 
 pub struct GuardedSocket {
@@ -13,15 +13,53 @@ impl GuardedSocket {
         Ok(self.listener.as_ref().unwrap().accept().await?)
     }
 
-    pub fn bind(path: PathBuf) -> Result<GuardedSocket> {
+    pub async fn bind(path: PathBuf) -> Result<GuardedSocket> {
+        Self::remove_if_stale(&path).await?;
+
         let listener = UnixListener::bind(&path).context(format!(
             "Failed to create socket file at {}.",
             &path.display()
         ))?;
+
         Ok(GuardedSocket {
             listener: Some(listener),
             path,
         })
+    }
+
+    async fn remove_if_stale(path: &PathBuf) -> Result<()> {
+        // Check to see if a socket already exists and is live
+        let err = match UnixStream::connect(&path).await {
+            Ok(_) => {
+                // success means the socket is live, so something else is using it
+                bail!("Another process is using the live socket at {} -- is another zeco client already running and connected to the same session?", &path.display())
+            }
+            Err(e) => e,
+        };
+
+        match err.kind() {
+            ErrorKind::NotFound | ErrorKind::ConnectionRefused => {}
+            _ => {
+                bail!(
+                    "Couldn't check whether socket file already exists and is live: {}",
+                    err
+                )
+            }
+        };
+
+        // socket file is stale/dangling symlink/nonexistent, safe to remove
+        if let Err(e) = std::fs::remove_file(path) {
+            if e.kind() == ErrorKind::NotFound {
+                // file doesn't exist, carry on
+            } else {
+                bail!(
+                    "Couldn't cleanup an existing socket file before attempting connection: {}",
+                    e
+                )
+            }
+        };
+
+        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::process::exit;
 
 use clap::Parser;
+mod guarded_socket;
 mod handshake;
 mod protocol;
 mod zellij;

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -139,7 +139,7 @@ pub async fn join(c: Connection) -> Result<()> {
         .context("Failed to create zellij directory")?;
     let remote_session_name = format!("{name}-remote");
     let local_socket_path = dir.join(&remote_session_name);
-    let guarded_socket = GuardedSocket::bind(local_socket_path)?;
+    let guarded_socket = GuardedSocket::bind(local_socket_path).await?;
     println!("Join session with");
     println!("\tzellij a {remote_session_name}");
     loop {

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -7,14 +7,12 @@ use std::{
 use anyhow::{bail, Context, Result};
 use directories::ProjectDirs;
 use iroh::endpoint::{Connection, RecvStream, SendStream};
-use tokio::{
-    fs::create_dir_all,
-    io::copy,
-    net::{UnixListener, UnixStream},
-    spawn,
-};
+use tokio::{fs::create_dir_all, io::copy, net::UnixStream, spawn};
 
-use crate::protocol::{EasyCodeRead, EasyCodeWrite};
+use crate::{
+    guarded_socket::GuardedSocket,
+    protocol::{EasyCodeRead, EasyCodeWrite},
+};
 
 #[derive(Debug, Clone)]
 pub struct ZellijSessionInfo {
@@ -135,17 +133,17 @@ pub async fn join(c: Connection) -> Result<()> {
     let name: String = s.struct_read().await?;
     println!("Remote Session is {name}. You too are expected to use version {version}.");
 
-    let remote_session_name = format!("{name}-remote");
-    let dir = get_base_path()?.join(version).display().to_string();
+    let dir = get_base_path()?.join(version);
     create_dir_all(&dir)
         .await
         .context("Failed to create zellij directory")?;
-    let local_socket = format!("{dir}/{remote_session_name}");
-    let listener = UnixListener::bind(local_socket).context("Failed to create socket file.")?;
+    let remote_session_name = format!("{name}-remote");
+    let local_socket_path = dir.join(&remote_session_name);
+    let guarded_socket = GuardedSocket::bind(local_socket_path)?;
     println!("Join session with");
     println!("\tzellij a {remote_session_name}");
     loop {
-        match listener.accept().await {
+        match guarded_socket.accept().await {
             Ok((stream, _)) => {
                 let c = c.clone();
                 spawn(handle_zellij_socket(stream, c));


### PR DESCRIPTION
## GuardedSocket

From commit message:

    Implement guard on socket file for cleanup

    Move UnixListener into a guarded socket so we can ensure the file
    descriptor gets closed before we attempt to remove the stale socket
    file. This handles cleanup of socket files on shutdown.

    Using GuardedSocket to bind may also set things up for a rebind loop
    later for reconnection attempts.

    Listener becomes an Option<UnixListener> so drop() can take ownership of
    it to close it right before file removal

    Thinly wrap UnixListener's accept() so callers don't need to reason
    about cleanup details

Wrapping the listener/socket file in a guard here lets us be sure that any returns and default panic unwinds out of `zellij::join()` clean up the stale socket file, so I chose that over simply removing the file at the end of the function. This PR is fast followed by another one which implements graceful shutdown using this and Tokio `CancellationToken`s, submitted separately for feedback.

I manually tested hosting and joining on both NixOS and MacOS Tahoe.

## Cleaning up pre-existing socket files

From commit message:

    If a zeco client is SIGKILL'd, it leaves behind a stale socket file
    named for the session. Future attempts to bind a socket at that path get
    EADDRINUSE. This checks to see if there's a pre-existing file and
    removes it if safe to do so. As written this will currently also remove
    files at the same path that aren't sockets.

I tested behavior in 3 ways:
1. Create non-socket files with e.g. `touch`, `echo`, `ln -s /tmp/nonexistent-target /path/to/socket`. Replaced with a socket upon join.
2. Create a stale socket with `kill -9 [zeco-pid]`, then restart it and join again. Stale socket is replaced.
3. Make a live socket with netcat, `nc -lU /path/to/socket`. zeco terminates with error:
```
Host let you in.
Remote Session is wise-elephant. You too are expected to use version contract_version_1.
Error, terminated due to:
Another process is using the live socket at /run/user/1000/zellij/contract_version_1/wise-elephant-remote -- is another zeco client already running and connected to the same session?
```

Finally, I also added some tests covering the cleanup of sockets before and after join, and that we don't clean up live sockets.