### PR TITLE
Use cancellation token for coordinating graceful shutdown

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -8,6 +8,7 @@ use iroh::{
 };
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::str::FromStr;
+use tokio_util::sync::CancellationToken;
 
 use crate::zellij::{self, get_current_session};
 
@@ -23,7 +24,7 @@ async fn init_endpoint() -> Result<Endpoint> {
         .map_err(|e| anyhow::anyhow!("failed to bind iroh endpoint: {e}"))
 }
 
-pub async fn handshake_host() -> Result<()> {
+pub async fn handshake_host(cancellation_token: &CancellationToken) -> Result<()> {
     let zellij_info = get_current_session()?;
     println!(
         "Sharing Zellij session {} (version {})",
@@ -62,10 +63,14 @@ pub async fn handshake_host() -> Result<()> {
     drop(send);
     drop(recv);
 
-    zellij::host(connection, zellij_info).await
+    zellij::host(connection, zellij_info, cancellation_token).await
 }
 
-pub async fn handshake_guest(node_id: &str, secret: &str) -> Result<()> {
+pub async fn handshake_guest(
+    node_id: &str,
+    secret: &str,
+    cancellation_token: &CancellationToken,
+) -> Result<()> {
     let endpoint_id: EndpointId = EndpointId::from_str(node_id)?;
     let endpoint = init_endpoint().await?;
 
@@ -82,5 +87,5 @@ pub async fn handshake_guest(node_id: &str, secret: &str) -> Result<()> {
     drop(send);
     drop(recv);
 
-    zellij::join(connection).await
+    zellij::join(connection, cancellation_token).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,17 @@
-use std::process::exit;
-
-use clap::Parser;
 mod guarded_socket;
 mod handshake;
 mod protocol;
 mod zellij;
+
+use std::process::exit;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tokio::{
+    select,
+    signal::{self, unix::SignalKind},
+};
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Parser)]
 pub struct JoinArgs {
@@ -23,13 +30,31 @@ pub enum Command {
 #[tokio::main]
 async fn main() {
     let args = Command::parse();
+    let cancellation_token = CancellationToken::new();
+    tokio::spawn(listen_for_shutdown(cancellation_token.clone()));
     let res = match args {
-        Command::Host => handshake::handshake_host().await,
-        Command::Join(args) => handshake::handshake_guest(&args.host, &args.secret).await,
+        Command::Host => handshake::handshake_host(&cancellation_token).await,
+        Command::Join(args) => {
+            handshake::handshake_guest(&args.host, &args.secret, &cancellation_token).await
+        }
     };
     if let Err(e) = res {
         println!("Error, terminated due to:");
         println!("{e:#}");
         exit(1);
     }
+}
+
+async fn listen_for_shutdown(cancellation_token: CancellationToken) -> Result<()> {
+    let mut sigterm_listener = signal::unix::signal(SignalKind::terminate())
+        .context("Couldn't set up SIGTERM listener")?;
+
+    select! {
+        _ = signal::ctrl_c() => {},
+        _ = sigterm_listener.recv() => {},
+    }
+
+    println!("Performing a graceful shutdown...");
+    cancellation_token.cancel();
+    Ok(())
 }

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -13,6 +13,7 @@ use crate::{
     guarded_socket::GuardedSocket,
     protocol::{EasyCodeRead, EasyCodeWrite},
 };
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone)]
 pub struct ZellijSessionInfo {
@@ -80,19 +81,29 @@ pub fn get_current_session() -> Result<ZellijSessionInfo> {
     })
 }
 
-pub async fn host(c: Connection, z: ZellijSessionInfo) -> Result<()> {
+pub async fn host(
+    c: Connection,
+    z: ZellijSessionInfo,
+    cancellation_token: &CancellationToken,
+) -> Result<()> {
     let mut s = c.open_uni().await?;
     s.struct_write(&z.version).await?;
     s.struct_write(&z.name).await?;
     println!("Sent zellij details");
     loop {
         let z = z.clone();
-        let x = c.accept_bi().await;
-        match x {
-            Ok((send, recv)) => {
-                spawn(handle_zellij_session(send, recv, z));
+        tokio::select! {
+            x = c.accept_bi() => {
+                match x {
+                    Ok((send, recv)) => {
+                        spawn(handle_zellij_session(send, recv, z));
+                    }
+                    Err(e) => bail!("Failed to accept channel from guest: {:?}", e),
+                }
             }
-            Err(e) => bail!("Failed to accept channel from guest: {:?}", e),
+            _ = cancellation_token.cancelled() => {
+                return Ok(())
+            }
         }
     }
 }
@@ -127,7 +138,7 @@ async fn handle_zellij_socket(mut socket_stream: UnixStream, c: Connection) -> R
     Ok(())
 }
 
-pub async fn join(c: Connection) -> Result<()> {
+pub async fn join(c: Connection, cancellation_token: &CancellationToken) -> Result<()> {
     let mut s = c.accept_uni().await?;
     let version: String = s.struct_read().await?;
     let name: String = s.struct_read().await?;
@@ -143,12 +154,19 @@ pub async fn join(c: Connection) -> Result<()> {
     println!("Join session with");
     println!("\tzellij a {remote_session_name}");
     loop {
-        match guarded_socket.accept().await {
-            Ok((stream, _)) => {
-                let c = c.clone();
-                spawn(handle_zellij_socket(stream, c));
+        tokio::select! {
+            result = guarded_socket.accept() => {
+                match result {
+                    Ok((stream, _)) => {
+                        let c = c.clone();
+                        spawn(handle_zellij_socket(stream, c));
+                    }
+                    Err(_) => println!("Failed to accept connection on socket."),
+                }
             }
-            Err(_) => println!("Failed to accept connection on socket."),
+            _ = cancellation_token.cancelled() => {
+                    return Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
It looks like I can't stack PRs from forks to upstream on github, so this includes all the changes from #11 and needs that merged first.

From commit message:

    Add a helper function in main.rs that can listen for either
    SIGINT/Ctrl-C or SIGTERM.

    Check for shutdown in host/join functions so they can exit normally or
    perform any other tasks needed. In the case of zellij::join(), this will
    drop the guarded socket and trigger cleanup

`zellij::host()` doesn't have anything to clean up, but I hope structuring this way will also make it easier to test later, just by setting up and cancelling in tests. I want to look into that soon too.

Tested on NixOS and MacOS. Let me know what you think :+1: 